### PR TITLE
fix: handling external_ip=false case

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "google_compute_instance" "vm" {
     dynamic "access_config" {
       for_each = var.external_ip == false ? [] : [1]
       content {
-        nat_ip = google_compute_address.ext_ip[0].address
+        nat_ip = var.external_ip ? google_compute_address.ext_ip[0].address : null
       }
     }
   }


### PR DESCRIPTION
Old code caused exception, because dynamic block is evaluated before applying for_each stanza.

Example of error when using with external_ip=false:

│ Error: Invalid index
│
│   on .terraform/modules/worker_main/main.tf line 82, in resource "google_compute_instance" "vm":
│   82:         nat_ip = google_compute_address.ext_ip[0].address
│     ├────────────────
│     │ google_compute_address.ext_ip is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.

<!--- If any section below doesn't make sense for your pull request, delete it please. -->
