### PR TITLE
Added network tier variable to set STANDARD network tier for VPN servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This Terraform module creates a Google Compute Engine instance with optional ext
 
 - Provision a Google Compute Engine instance.
 - Optionally create an external IP for the instance.
+- Set network tier for external network (we use PREMIUM by default).
 - Attach an additional disk with optional snapshot scheduling and backup policy.
 - Configure SSH keys, service accounts, labels, and network settings.
 - Support for custom machine types, disk types, and automatic backups.
@@ -48,6 +49,7 @@ module "eth_api" {
 | subnetwork            | Subnetwork for the instance                                                                                                      | string       | n/a           | yes      |
 | zone                  | Zone for the instance                                                                                                            | string       | n/a           | yes      |
 | image                 | [The image to use for the boot disk](https://cloud.google.com/compute/docs/images/os-details)                                    | string       | n/a           | yes      |
+| network_tier          | Network tier for external IPs (STANDARD or PREMIUM).                                                                             | string       | PREMIUM       | no       |
 | machine_type          | [Machine type for the instance](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) | string       | e2-standard-2 | no       |
 | extra_disk_name       | Custom name for the additional disk                                                                                              | string       | ""            | no       |
 | extra_disk_size       | Size of the additional disk (GB), set to 0 to disable                                                                            | number       | 0             | no       |

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ resource "google_compute_address" "ext_ip" {
   name         = "ext-ip-${var.name}"
   description  = "External IP for ${var.name} in ${var.env} environment"
   address_type = "EXTERNAL"
+  network_tier = var.network_tier
   region       = substr(var.zone, 0, length(var.zone) - 2)
 }
 
@@ -89,7 +90,8 @@ resource "google_compute_instance" "vm" {
     dynamic "access_config" {
       for_each = var.external_ip == false ? [] : [1]
       content {
-        nat_ip = var.external_ip ? google_compute_address.ext_ip[0].address : null
+        nat_ip       = var.external_ip ? google_compute_address.ext_ip[0].address : null
+        network_tier = var.network_tier
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "external_ip" {
   description = "Access configurations, i.e. IPs via which this instance can be accessed via the Internet."
 }
 
+variable "network_tier" {
+  type        = string
+  default     = "PREMIUM"
+  description = "Network tier for external IPs (STANDARD or PREMIUM)."
+}
+
 variable "snapshot_schedule_days_in_cycle" {
   type        = number
   default     = 1


### PR DESCRIPTION
### Description

Added network tier variable to set STANDARD network tier for VPN servers.

### Code review notes

I've tested patch [here](https://github.com/lidofinance/tf-vpn-infra/tree/feature/gcp).

### Changes ([help](https://www.conventionalcommits.org/en/v1.0.0/#summary))

- feat: variable to set network_tier for instances (as before we have PREMIUM)
